### PR TITLE
chown for directory and symlink

### DIFF
--- a/src/hookfs/async_fs.rs
+++ b/src/hookfs/async_fs.rs
@@ -82,7 +82,14 @@ pub trait AsyncFileSystemImpl: Send + Sync {
 
     async fn rmdir(&self, parent: u64, name: OsString) -> Result<()>;
 
-    async fn symlink(&self, parent: u64, name: OsString, link: PathBuf) -> Result<Entry>;
+    async fn symlink(
+        &self,
+        parent: u64,
+        name: OsString,
+        link: PathBuf,
+        uid: u32,
+        gid: u32,
+    ) -> Result<Entry>;
 
     async fn rename(
         &self,

--- a/src/hookfs/async_fs.rs
+++ b/src/hookfs/async_fs.rs
@@ -314,9 +314,7 @@ impl<T: AsyncFileSystemImpl + 'static> Filesystem for AsyncFileSystem<T> {
         let async_impl = self.0.clone();
         let name = name.to_owned();
         spawn_reply(req.unique(), reply, async move {
-            async_impl
-                .mkdir(parent, name, mode, umask, uid, gid)
-                .await
+            async_impl.mkdir(parent, name, mode, umask, uid, gid).await
         });
     }
     fn unlink(&mut self, req: &Request, parent: u64, name: &std::ffi::OsStr, reply: ReplyEmpty) {

--- a/src/hookfs/async_fs.rs
+++ b/src/hookfs/async_fs.rs
@@ -349,8 +349,10 @@ impl<T: AsyncFileSystemImpl + 'static> Filesystem for AsyncFileSystem<T> {
         let async_impl = self.0.clone();
         let name = name.to_owned();
         let link = link.to_owned();
+        let uid = req.uid();
+        let gid = req.gid();
         spawn_reply(req.unique(), reply, async move {
-            async_impl.symlink(parent, name, link).await
+            async_impl.symlink(parent, name, link, uid, gid).await
         });
     }
     fn rename(

--- a/src/hookfs/mod.rs
+++ b/src/hookfs/mod.rs
@@ -21,7 +21,7 @@ use nix::sys::stat;
 use nix::sys::statfs;
 use nix::sys::time::{TimeVal, TimeValLike};
 use nix::unistd::{
-    chown, fchownat, fsync, linkat, mkdir, symlinkat, truncate, unlink, AccessFlags, FchownatFlags,
+    fchownat, fsync, linkat, mkdir, symlinkat, truncate, unlink, AccessFlags, FchownatFlags,
     Gid, LinkatFlags, Uid,
 };
 
@@ -413,7 +413,7 @@ impl AsyncFileSystemImpl for HookFs {
         };
         inject!(self, SETATTR, &path);
 
-        async_lchown(&path, uid, gid)?;
+        async_lchown(&path, uid, gid).await?;
 
         if let Some(mode) = mode {
             async_fchmodat(&path, mode).await?;
@@ -521,7 +521,7 @@ impl AsyncFileSystemImpl for HookFs {
         trace!("create directory with mode: {:?}", mode);
         async_mkdir(&path, mode).await?;
         trace!("setting owner {}:{}", uid, gid);
-        async_lchown(&path, Some(uid), Some(gid))?;
+        async_lchown(&path, Some(uid), Some(gid)).await?;
 
         self.lookup(parent, name).await
     }
@@ -588,7 +588,7 @@ impl AsyncFileSystemImpl for HookFs {
         spawn_blocking(move || symlinkat(&link, None, &path)).await??;
 
         trace!("setting owner {}:{}", uid, gid);
-        async_lchown(&link, Some(uid), Some(gid))?;
+        async_lchown(&link, Some(uid), Some(gid)).await?;
 
         self.lookup(parent, name).await
     }
@@ -1166,7 +1166,7 @@ impl AsyncFileSystemImpl for HookFs {
 
         let fd = async_open(&path, filtered_flags, mode).await?;
         trace!("setting owner {}:{} for file", uid, gid);
-        async_lchown(fd, Some(uid), Some(gid))?;
+        async_lchown(fd, Some(uid), Some(gid)).await?;
 
         let stat = self.get_file_attr(&path).await?;
 

--- a/src/hookfs/mod.rs
+++ b/src/hookfs/mod.rs
@@ -1165,7 +1165,7 @@ impl AsyncFileSystemImpl for HookFs {
         let mode = stat::Mode::from_bits_truncate(mode);
 
         trace!("create with flags: {:?}, mode: {:?}", filtered_flags, mode);
-
+        let fd = async_open(&path, filtered_flags, mode).await?;
         trace!("setting owner {}:{} for file", uid, gid);
         async_lchown(&path, Some(uid), Some(gid)).await?;
 
@@ -1177,7 +1177,6 @@ impl AsyncFileSystemImpl for HookFs {
             .await
             .insert_path(stat.ino, path.clone());
 
-        let fd = async_open(&path, filtered_flags, mode).await?;
         let std_file = unsafe { std::fs::File::from_raw_fd(fd) };
         let file = fs::File::from_std(std_file);
         let fh = self

--- a/src/hookfs/mod.rs
+++ b/src/hookfs/mod.rs
@@ -527,7 +527,7 @@ impl AsyncFileSystemImpl for HookFs {
             Some(Uid::from_raw(uid)),
             Some(Gid::from_raw(gid)),
             FchownatFlags::FollowSymlink,
-        );
+        )?;
 
         self.lookup(parent, name).await
     }


### PR DESCRIPTION
Signed-off-by: STRRL <str_ruiling@outlook.com>

Fix https://github.com/chaos-mesh/toda/issues/10

Changes:

 - Calling `lchown` after `mkdir`.
 - Calling `lchown` after `symlink`.

As `nix` do not provide `lchown` directly, I use `fchownat` with flag `FchownatFlags::NoFollowSymlink` instead.

Manually test passed.