### PR TITLE
fix(src/main): There are unused variables and unused import elements

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -40,7 +40,7 @@ use std::{io, thread};
 
 use anyhow::Result;
 use injector::InjectorConfig;
-use jsonrpc::{start_server, Comm};
+use jsonrpc::start_server;
 use mount_injector::{MountInjectionGuard, MountInjector};
 use nix::sys::signal::{signal, SigHandler, Signal};
 use nix::unistd::{pipe, read, write};
@@ -179,7 +179,7 @@ fn main() -> Result<()> {
         Err(e) => Err(anyhow::Error::msg(e.to_string())),
     };
 
-    let (tx, rx) = mpsc::channel();
+    let (tx, _rx) = mpsc::channel();
     {
         let hookfs = match &mount_injector {
             Ok(e) => Some(e.hookfs.clone().into()),


### PR DESCRIPTION
There are unused variables and unused import elements.

$ make debug
cargo build
   Compiling toda v0.2.0 (/home/toda)
warning: unused import: `Comm`
  --> src/main.rs:43:29
   |
43 | use jsonrpc::{start_server, Comm};
   |                             ^^^^
   |
   = note: `#[warn(unused_imports)]` on by default

warning: unused variable: `rx`
   --> src/main.rs:182:14
    |
182 |     let (tx, rx) = mpsc::channel();
    |              ^^ help: if this is intentional, prefix it with an underscore: `_rx`
    |
    = note: `#[warn(unused_variables)]` on by default

warning: 2 warnings emitted

    Finished dev [unoptimized + debuginfo] target(s) in 14.78s