### PR TITLE
fix: appending nonempty when mount fuse

### DIFF
--- a/src/mount_injector.rs
+++ b/src/mount_injector.rs
@@ -130,7 +130,7 @@ impl MountInjector {
 
             std::fs::create_dir_all(new_path.as_path())?;
 
-            let args = ["allow_other", "fsname=toda", "default_permissions"];
+            let args = ["allow_other", "fsname=toda", "default_permissions", "nonempty"];
             let flags: Vec<_> = args
                 .iter()
                 .flat_map(|item| vec![OsStr::new("-o"), OsStr::new(item)])


### PR DESCRIPTION
Signed-off-by: STRRL <str_ruiling@outlook.com>

close https://github.com/chaos-mesh/toda/issues/30

- append new option `-o nonempty` when mounting