### PR TITLE
Update nix dependency to address CVE-2021-45707

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,2 +1,0 @@
-[build]
-rustflags = ["-Z", "relro-level=full"]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -76,6 +76,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
 
 [[package]]
+name = "bitflags"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "327762f6e5a765692301e5bb513e0d9fef63be86bbc14528052b1cd3e6f03e07"
+
+[[package]]
 name = "byteorder"
 version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -92,12 +98,6 @@ name = "bytes"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4872d67bab6358e59559027aa3b9157c53d9358c51423c17554809a8858e0f8"
-
-[[package]]
-name = "cc"
-version = "1.0.66"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c0496836a84f8d0495758516b8621a622beb77c0fed418570e50764093ced48"
 
 [[package]]
 name = "cfg-if"
@@ -132,7 +132,7 @@ checksum = "37e58ac78573c40708d45522f0d80fa2f01cc4f9b4e2bf749807255454312002"
 dependencies = [
  "ansi_term 0.11.0",
  "atty",
- "bitflags",
+ "bitflags 1.2.1",
  "strsim",
  "textwrap",
  "unicode-width",
@@ -165,7 +165,7 @@ version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d7d1242462849390bb2ad38aeed769499f1afc7383affa2ab0c1baa894c0200"
 dependencies = [
- "bitflags",
+ "bitflags 1.2.1",
  "byteorder",
  "lazy_static",
  "proc-macro-error",
@@ -216,7 +216,7 @@ version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2e9763c69ebaae630ba35f74888db465e49e259ba1bc0eda7d06f4a067615d82"
 dependencies = [
- "bitflags",
+ "bitflags 1.2.1",
  "fuchsia-zircon-sys",
 ]
 
@@ -539,9 +539,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.82"
+version = "0.2.149"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89203f3fba0a3795506acaad8ebce3c80c0af93f994d5a1d7a0b1eeb23271929"
+checksum = "a08173bc88b7955d1b3145aa561539096c421ac8debde8cbc3612ec635fee29b"
 
 [[package]]
 name = "libflate"
@@ -686,13 +686,12 @@ dependencies = [
 
 [[package]]
 name = "nix"
-version = "0.18.0"
+version = "0.27.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83450fe6a6142ddd95fb064b746083fc4ef1705fe81f64a64e1d4b39f54a1055"
+checksum = "2eb04e9c688eff1c89d72b407f168cf79bb9e867a9d3323ed6c01519eb9cc053"
 dependencies = [
- "bitflags",
- "cc",
- "cfg-if 0.1.10",
+ "bitflags 2.4.1",
+ "cfg-if 1.0.0",
  "libc",
 ]
 
@@ -872,7 +871,7 @@ version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4a336c8310f4955f343935b9c11a30254d1ad8fad98ec257a4407a061a6fd49"
 dependencies = [
- "bitflags",
+ "bitflags 1.2.1",
  "byteorder",
  "chrono",
  "hex",
@@ -937,7 +936,7 @@ version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94341e4e44e24f6b591b59e47a8a027df12e008d73fd5672dbea9cc22f4507d9"
 dependencies = [
- "bitflags",
+ "bitflags 1.2.1",
 ]
 
 [[package]]
@@ -1187,7 +1186,7 @@ version = "0.2.3"
 dependencies = [
  "anyhow",
  "async-trait",
- "bitflags",
+ "bitflags 1.2.1",
  "derive_more",
  "dynasmrt",
  "env_logger",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2018"
 
 [dependencies]
 structopt = "0.3"
-nix = "0.18"
+nix = {version = "0.27.1", features = ["dir", "fs", "mman", "mount", "process", "ptrace", "signal", "uio", "user"]}
 anyhow = "1.0"
 fuser = {version = "0.6", features = ["abi-7-19"]}
 time = "0.1"

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ ENV https_proxy $HTTPS_PROXY
 
 RUN apt-get update && apt-get install build-essential curl git pkg-config libfuse-dev fuse -y && rm -rf /var/lib/apt/lists/*
 
-RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain nightly-2021-12-23 -y
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain stable -y
 ENV PATH "/root/.cargo/bin:${PATH}"
 
 RUN if [ -n "$HTTP_PROXY" ]; then echo "[http]\n\
@@ -24,7 +24,6 @@ COPY . /toda-build
 
 WORKDIR /toda-build
 
-ENV RUSTFLAGS "-Z relro-level=full"
 RUN --mount=type=cache,target=/toda-build/target \
     --mount=type=cache,target=/root/.cargo/registry \
     cargo build --release

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,1 +1,1 @@
-nightly-2021-12-23
+stable

--- a/src/fuse_device.rs
+++ b/src/fuse_device.rs
@@ -1,18 +1,16 @@
 use nix::sys::stat::{makedev, mknod, Mode, SFlag};
-use nix::Error as NixError;
 
 pub fn mkfuse_node() -> anyhow::Result<()> {
-    let mode = unsafe { Mode::from_bits_unchecked(0o666) };
+    let mode = Mode::S_IWUSR | Mode::S_IRUSR | Mode::S_IWGRP | Mode::S_IRGRP | Mode::S_IWOTH | Mode::S_IROTH;
     let dev = makedev(10, 229);
     match mknod("/dev/fuse", SFlag::S_IFCHR, mode, dev) {
         Ok(()) => Ok(()),
-        Err(NixError::Sys(errno)) => {
+        Err(errno) => {
             if errno == nix::errno::Errno::EEXIST {
                 Ok(())
             } else {
-                Err(NixError::from_errno(errno).into())
+                Err(errno.into())
             }
         }
-        Err(err) => Err(err.into()),
     }
 }

--- a/src/hookfs/errors.rs
+++ b/src/hookfs/errors.rs
@@ -36,15 +36,8 @@ impl HookFsError {
 }
 
 impl From<nix::Error> for HookFsError {
-    fn from(err: Error) -> HookFsError {
-        // TODO: match more error types
-        match err {
-            Error::Sys(errno) => HookFsError::Sys(errno),
-            _ => {
-                error!("unknown error {:?}", err);
-                HookFsError::UnknownError
-            }
-        }
+    fn from(errno: Error) -> HookFsError {
+        HookFsError::Sys(errno)
     }
 }
 

--- a/src/hookfs/mod.rs
+++ b/src/hookfs/mod.rs
@@ -4,7 +4,7 @@ mod reply;
 pub mod runtime;
 mod utils;
 
-use std::collections::{HashMap, LinkedList};
+use std::collections::HashMap;
 use std::ffi::{CString, OsStr, OsString};
 use std::os::unix::ffi::OsStrExt;
 use std::os::unix::io::RawFd;
@@ -159,12 +159,12 @@ pub struct HookFs {
 struct Node {
     pub ref_count: u64,
     // TODO: optimize paths with a combination data structure
-    paths: LinkedList<PathBuf>,
+    paths: Vec<PathBuf>,
 }
 
 impl Node {
     fn get_path(&self) -> Option<&Path> {
-        self.paths.back().map(|item| item.as_path())
+        self.paths.last().map(|item| item.as_path())
     }
 
     fn insert(&mut self, path: PathBuf) {
@@ -174,11 +174,11 @@ impl Node {
             }
         }
 
-        self.paths.push_back(path);
+        self.paths.push(path);
     }
 
     fn remove(&mut self, path: &Path) {
-        self.paths.drain_filter(|x| x == path);
+        self.paths.retain(|x| x != path);
     }
 }
 

--- a/src/hookfs/mod.rs
+++ b/src/hookfs/mod.rs
@@ -728,7 +728,7 @@ impl AsyncFileSystemImpl for HookFs {
         // filter out append. The kernel layer will translate the
         // offsets for us appropriately.
         let filtered_flags = flags & (!libc::O_APPEND) & (!libc::O_DIRECT);
-        let filtered_flags = OFlag::from_bits_truncate(filtered_flags as i32);
+        let filtered_flags = OFlag::from_bits_truncate(filtered_flags);
 
         let inode_map = self.inode_map.read().await;
         let path = inode_map.get_path(ino)?;
@@ -849,7 +849,7 @@ impl AsyncFileSystemImpl for HookFs {
         let inode_map = self.inode_map.read().await;
         let path = { inode_map.get_path(ino)?.to_owned() };
         let filtered_flags = flags & (!libc::O_APPEND);
-        let filtered_flags = OFlag::from_bits_truncate(filtered_flags as i32);
+        let filtered_flags = OFlag::from_bits_truncate(filtered_flags);
 
         let path_clone = path.clone();
         let dir = spawn_blocking(move || {
@@ -889,7 +889,7 @@ impl AsyncFileSystemImpl for HookFs {
             trace!("empty reply");
             return Ok(());
         }
-        for (index, entry) in all_entries.iter().enumerate().skip(offset as usize) {
+        for (index, entry) in all_entries.iter().enumerate().skip(offset) {
             let entry = (*entry)?;
 
             let name = entry.file_name();
@@ -990,9 +990,6 @@ impl AsyncFileSystemImpl for HookFs {
         let cpath = CString::new(path.as_os_str().as_bytes())?;
         let name = CString::new(name.as_bytes())?;
 
-        let mut buf = Vec::new();
-        buf.resize(size as usize, 0u8);
-
         let data = async_getxattr(cpath, name, size as usize).await?;
 
         let mut reply = if size == 0 {
@@ -1016,8 +1013,7 @@ impl AsyncFileSystemImpl for HookFs {
         let path = inode_map.get_path(ino)?.to_owned();
         let cpath = CString::new(path.as_os_str().as_bytes())?;
 
-        let mut buf = Vec::new();
-        buf.resize(size as usize, 0u8);
+        let buf = vec![0u8; size as usize];
 
         let shared_buf = std::sync::Arc::new(buf);
         let buf_clone = shared_buf.clone();
@@ -1073,7 +1069,7 @@ impl AsyncFileSystemImpl for HookFs {
 
         let inode_map = self.inode_map.read().await;
         let path = inode_map.get_path(ino)?.to_owned();
-        let mask = AccessFlags::from_bits_truncate(mask as i32);
+        let mask = AccessFlags::from_bits_truncate(mask);
         let path_clone = path.to_path_buf();
 
         spawn_blocking(move || nix::unistd::access(&path_clone, mask)).await??;
@@ -1102,7 +1098,7 @@ impl AsyncFileSystemImpl for HookFs {
         };
 
         let filtered_flags = flags & (!libc::O_APPEND);
-        let filtered_flags = OFlag::from_bits_truncate(filtered_flags as i32);
+        let filtered_flags = OFlag::from_bits_truncate(filtered_flags);
         let mode = stat::Mode::from_bits_truncate(mode);
 
         trace!("create with flags: {:?}, mode: {:?}", filtered_flags, mode);
@@ -1180,14 +1176,13 @@ async fn async_setxattr(path: CString, name: CString, data: Vec<u8>, flags: i32)
 
 async fn async_getxattr(path: CString, name: CString, size: usize) -> Result<Vec<u8>> {
     spawn_blocking(move || {
-        let mut buf = Vec::new();
-        buf.resize(size, 0);
+        let mut buf = vec![0; size];
 
         let path_ptr = &path.as_bytes_with_nul()[0] as *const u8 as *const libc::c_char;
         let name_ptr = &name.as_bytes_with_nul()[0] as *const u8 as *const libc::c_char;
         let buf_ptr = buf.as_slice() as *const [u8] as *mut [u8] as *mut libc::c_void;
 
-        let ret = unsafe { lgetxattr(path_ptr, name_ptr, buf_ptr, size as usize) };
+        let ret = unsafe { lgetxattr(path_ptr, name_ptr, buf_ptr, size) };
         if ret == -1 {
             Err(Error::last())
         } else {
@@ -1200,8 +1195,7 @@ async fn async_getxattr(path: CString, name: CString, size: usize) -> Result<Vec
 
 async fn async_read(fd: RawFd, count: usize, offset: i64) -> Result<Vec<u8>> {
     spawn_blocking(move || unsafe {
-        let mut buf = Vec::new();
-        buf.resize(count, 0);
+        let mut buf = vec![0; count];
         let ret = libc::pread(fd, buf.as_ptr() as *mut c_void, count, offset);
         if ret == -1 {
             Err(Error::last())

--- a/src/injector/multi_injector.rs
+++ b/src/injector/multi_injector.rs
@@ -25,16 +25,16 @@ impl MultiInjector {
         for injector in conf.into_iter() {
             let injector = match injector {
                 InjectorConfig::Fault(faults) => {
-                    (box FaultInjector::build(faults)?) as Box<dyn Injector>
+                    (Box::new(FaultInjector::build(faults)?)) as Box<dyn Injector>
                 }
                 InjectorConfig::Latency(latency) => {
-                    (box LatencyInjector::build(latency)?) as Box<dyn Injector>
+                    (Box::new(LatencyInjector::build(latency)?)) as Box<dyn Injector>
                 }
                 InjectorConfig::AttrOverride(attr_override) => {
-                    (box AttrOverrideInjector::build(attr_override)?) as Box<dyn Injector>
+                    (Box::new(AttrOverrideInjector::build(attr_override)?)) as Box<dyn Injector>
                 }
                 InjectorConfig::Mistake(mistakes) => {
-                    (box MistakeInjector::build(mistakes)?) as Box<dyn Injector>
+                    (Box::new(MistakeInjector::build(mistakes)?)) as Box<dyn Injector>
                 }
             };
             injectors.push(injector)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,11 +11,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#![feature(box_syntax)]
-#![feature(async_closure)]
-#![feature(vec_into_raw_parts)]
-#![feature(atomic_mut_ptr)]
-#![feature(drain_filter)]
 #![allow(clippy::or_fun_call)]
 #![allow(clippy::too_many_arguments)]
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,11 +11,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#![feature(box_syntax)]
-#![feature(async_closure)]
-#![feature(vec_into_raw_parts)]
-#![feature(atomic_mut_ptr)]
-#![feature(drain_filter)]
 #![allow(clippy::or_fun_call)]
 #![allow(clippy::too_many_arguments)]
 

--- a/src/mount.rs
+++ b/src/mount.rs
@@ -21,7 +21,7 @@ impl MountsInfo {
     pub fn non_root<P: AsRef<Path>>(&self, path: P) -> Result<bool> {
         let mount_points = self.mounts.iter().map(|item| &item.mount_point);
         for mount_point in mount_points {
-            if path.as_ref().starts_with(&mount_point) {
+            if path.as_ref().starts_with(mount_point) {
                 // The relationship is "contain" because if we want to inject /a/b, and /a is a mount point, we can still
                 // use this method.
                 return Ok(true);

--- a/src/mount_injector.rs
+++ b/src/mount_injector.rs
@@ -125,7 +125,7 @@ impl MountInjector {
         let cloned_hookfs = hookfs.clone();
 
         let (before_mount_waiter, before_mount_guard) = stop::lock();
-        let handler = std::thread::spawn(box move || {
+        let handler = std::thread::spawn(Box::new(move || {
             let fs = hookfs::AsyncFileSystem::from(cloned_hookfs);
 
             std::fs::create_dir_all(new_path.as_path())?;
@@ -144,7 +144,7 @@ impl MountInjector {
             drop(hookfs::runtime::RUNTIME.write().unwrap().take().unwrap());
 
             Ok(())
-        });
+        }));
         // TODO: remove this. But wait for FUSE gets up
         // Related Issue: https://github.com/zargony/fuse-rs/issues/9
         before_mount_waiter.wait();

--- a/src/replacer/fd_replacer.rs
+++ b/src/replacer/fd_replacer.rs
@@ -105,9 +105,11 @@ impl ProcessAccessor {
         let mut new_paths = Vec::new();
         self.new_paths.read_to_end(&mut new_paths)?;
 
-        let (cases_ptr, length, _) = self.cases.clone().into_raw_parts();
+        let cases = &mut *self.cases.clone();
+        let length = cases.len();
+        let cases_ptr = &mut cases[0] as *mut ReplaceCase as *mut u8;
         let size = length * std::mem::size_of::<ReplaceCase>();
-        let cases = unsafe { std::slice::from_raw_parts(cases_ptr as *mut u8, size) };
+        let cases = unsafe { std::slice::from_raw_parts(cases_ptr, size) };
 
         self.process.run_codes(|addr| {
             let mut vec_rt =

--- a/src/replacer/fd_replacer.rs
+++ b/src/replacer/fd_replacer.rs
@@ -106,9 +106,8 @@ impl ProcessAccessor {
         self.new_paths.read_to_end(&mut new_paths)?;
 
         let cases = &mut *self.cases.clone();
-        let length = cases.len();
         let cases_ptr = &mut cases[0] as *mut ReplaceCase as *mut u8;
-        let size = length * std::mem::size_of::<ReplaceCase>();
+        let size = std::mem::size_of_val(cases);
         let cases = unsafe { std::slice::from_raw_parts(cases_ptr, size) };
 
         self.process.run_codes(|addr| {
@@ -229,7 +228,7 @@ impl FdReplacer {
                     .filter(|(_, path)| path.starts_with(detect_path))
                     .filter_map(move |(fd, path)| {
                         trace!("replace fd({}): {}", fd, path.display());
-                        let stripped_path = path.strip_prefix(&detect_path).ok()?;
+                        let stripped_path = path.strip_prefix(detect_path).ok()?;
                         Some((process.clone(), (fd, new_path.join(stripped_path))))
                     })
             })

--- a/src/replacer/mmap_replacer.rs
+++ b/src/replacer/mmap_replacer.rs
@@ -155,9 +155,8 @@ impl ProcessAccessor {
         self.new_paths.read_to_end(&mut new_paths)?;
 
         let cases = &mut *self.cases.clone();
-        let length = cases.len();
         let cases_ptr = &mut cases[0] as *mut RawReplaceCase as *mut u8;
-        let size = length * std::mem::size_of::<RawReplaceCase>();
+        let size = std::mem::size_of_val(cases);
         let cases = unsafe { std::slice::from_raw_parts(cases_ptr, size) };
 
         self.process.run_codes(|addr| {
@@ -315,7 +314,7 @@ impl MmapReplacer {
                     })
                     .filter(|(_, case)| case.path.starts_with(detect_path))
                     .filter_map(|(process, mut case)| {
-                        let stripped_path = case.path.strip_prefix(&detect_path).ok()?;
+                        let stripped_path = case.path.strip_prefix(detect_path).ok()?;
                         case.path = new_path.join(stripped_path);
                         Some((process, case))
                     })

--- a/src/replacer/mmap_replacer.rs
+++ b/src/replacer/mmap_replacer.rs
@@ -154,9 +154,11 @@ impl ProcessAccessor {
         let mut new_paths = Vec::new();
         self.new_paths.read_to_end(&mut new_paths)?;
 
-        let (cases_ptr, length, _) = self.cases.clone().into_raw_parts();
+        let cases = &mut *self.cases.clone();
+        let length = cases.len();
+        let cases_ptr = &mut cases[0] as *mut RawReplaceCase as *mut u8;
         let size = length * std::mem::size_of::<RawReplaceCase>();
-        let cases = unsafe { std::slice::from_raw_parts(cases_ptr as *mut u8, size) };
+        let cases = unsafe { std::slice::from_raw_parts(cases_ptr, size) };
 
         self.process.run_codes(|addr| {
             let mut vec_rt =


### PR DESCRIPTION
Updating `nix` to latest required updating `rustc`. This prompted a change to use `stable` instead of the old `nightly` channel build from 2021.

I think the switch from nightly is justified:
- Full relro is the default behaviour on Linux and x64, which is the only possible current target for this repo as far as I can tell, so the experimental build flag is not required.
- `Vec::into_raw_parts` is experimental, but not necessary and you can work around its absence.
- `LinkedList::drain_filter` is not necessary, given there doesn't appear to be any benefit to using a linked list in this case. A simple `Vec` suffices for the stack-like usage, and it provides `retain` to remove all non-matching items.

File built on `stable` with no `-Z relro-level=full` option:
```
❯ checksec --file=./toda 
RELRO           STACK CANARY      NX            PIE             RPATH      RUNPATH	Symbols		FORTIFY	Fortified	Fortifiable  FILE
Full RELRO      No canary found   NX enabled    PIE enabled     No RPATH   No RUNPATH   19690 Symbols     No	0		10	./toda
```