### PR TITLE
Run test on CI one by one

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -23,7 +23,7 @@ jobs:
     - name: Add user_allow_other to /etc/fuse.conf
       run: echo "user_allow_other" | sudo tee -a /etc/fuse.conf
     - name: Run tests
-      run: cargo test --verbose
+      run: cargo test --verbose -- --test-threads=1
   clippy_check:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
It seems that running multiple FUSE tests at the same time will make it quite unstable. I don't know whether `libfuse` has some internal globally sharing state which makes it unstable to run tests parallely.

This PR adds a flag to the github CI file and make it run tests serially. It should works fine now.